### PR TITLE
feat: add api for running text input as attempt

### DIFF
--- a/doc/attempt.txt
+++ b/doc/attempt.txt
@@ -165,8 +165,38 @@ run({bufnr})                                                   *attempt.run()*
         have to manage how it's run. Use nil to run the
         current buffer
 
+run_lines({lines}, {ext}, {cb})                                 *attempt.run_lines()*
+    Description: Run attempt with the configuration in |attempt-config-run| on
+    code found in the passed in {lines}
+
+    Attributes: ~
+        {async}
+
+    Parameters: ~
+        {lines}:        (list<string>)
+        A new-line separated list of code lines
+        {ext}:          (string|nil)
+        The extension used for evaluating the code. Must be present in the
+        ext_options config option. If not provided, the current buffers ext is
+        used instead
+        {cb}:           (function)
+        Function to be called after the attempt is run to completion, with the
+        bufnr and the |attempt-file_entry| as parameters
+
 open_select({cb})                                      *attempt.open_select()*
     Description: Opens existing attempt, letting you choose with
+    |vim.ui.select|
+
+    Attributes: ~
+        {async}
+
+    Parameters: ~
+        {cb} (function):
+            Function to be called after opening, with the
+            |attempt-file_entry| as parameter
+
+open_extension_select({cb})                             *attempt.open_extension_select()*
+    Description: Opens |attempt-ext_options|, letting you choose with
     |vim.ui.select|
 
     Attributes: ~

--- a/lua/attempt.lua
+++ b/lua/attempt.lua
@@ -32,7 +32,11 @@ M.new_input_ext = req('attempt.interface', 'new_input_ext')
 
 M.run = req('attempt.interface', 'run')
 
+M.run_lines = req('attempt.interface', 'run_lines')
+
 M.open_select = req('attempt.interface', 'open_select')
+
+M.select_extension = req('attempt.interface', 'select_extension')
 
 M.delete = req('attempt.interface', 'delete')
 

--- a/lua/attempt.lua
+++ b/lua/attempt.lua
@@ -36,7 +36,7 @@ M.run_lines = req('attempt.interface', 'run_lines')
 
 M.open_select = req('attempt.interface', 'open_select')
 
-M.select_extension = req('attempt.interface', 'select_extension')
+M.open_extension_select = req('attempt.interface', 'open_extension_select')
 
 M.delete = req('attempt.interface', 'delete')
 

--- a/lua/attempt/interface.lua
+++ b/lua/attempt/interface.lua
@@ -116,8 +116,10 @@ function M.open_select(cb)
   end)
 end
 
-function M.select_extension(cb)
-  vim.notify("TODO: implement select_extension")
+function M.open_extension_select(cb)
+  vim.ui.select(config.opts.ext_options, {
+    prompt = "Select extension",
+  }, cb)
 end
 
 function M.delete(path, cb)

--- a/lua/attempt/interface.lua
+++ b/lua/attempt/interface.lua
@@ -79,7 +79,7 @@ function M.run_lines(lines, ext, cb)
         vim.cmd(cmd)
       end
     elseif type(run_cmds) == 'string' then
-        vim.cmd(run_cmds)
+      vim.cmd(run_cmds)
     else
       run_cmds(ext, bufnr)
     end

--- a/lua/attempt/manager.lua
+++ b/lua/attempt/manager.lua
@@ -64,6 +64,24 @@ function M.new(opts, cb)
   end)
 end
 
+function M.new_tmp(opts, cb)
+  filedata.new_file_tmp({
+    filename = opts.filename or 'scratch-tmp',
+    ext = opts.ext,
+    initial_content = opts.initial_content
+  }, function(file_entry)
+    vim.notify(vim.inspect(file_entry))
+    vim.schedule(function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_name(bufnr, file_entry.path)
+      vim.api.nvim_buf_set_option(bufnr, 'buftype', '')
+      if cb then
+        cb(bufnr, file_entry)
+      end
+    end)
+  end)
+end
+
 function M.list(cb)
   filedata.get(function (data)
     vim.schedule(function()

--- a/lua/attempt/manager.lua
+++ b/lua/attempt/manager.lua
@@ -70,7 +70,6 @@ function M.new_tmp(opts, cb)
     ext = opts.ext,
     initial_content = opts.initial_content
   }, function(file_entry)
-    vim.notify(vim.inspect(file_entry))
     vim.schedule(function()
       local bufnr = vim.api.nvim_create_buf(false, true)
       vim.api.nvim_buf_set_name(bufnr, file_entry.path)


### PR DESCRIPTION
closes #11 

this PR adds the `run_lines` and `open_extension_select` apis, which allows the user to run an attempt using a list of lines as code.

instead of opening ad attempt in a separate buffer and then running it, you can now use this api to run code you have in your visual selection, code in a register, or your clipboard as a few examples.

the `open_extension_select` is a convenience wrapper for selecting an extension from the configured `config.opts.ext_options` before passing the chosen ext to `run_lines`.